### PR TITLE
Update bybit_gateway.py

### DIFF
--- a/vnpy_bybit/bybit_gateway.py
+++ b/vnpy_bybit/bybit_gateway.py
@@ -18,7 +18,8 @@ from vnpy.trader.constant import (
     Interval,
     OrderType,
     Product,
-    Status
+    Status,
+    Offset
 )
 from vnpy.trader.gateway import BaseGateway
 from vnpy.trader.object import (
@@ -97,6 +98,9 @@ symbols_swap: List[str] = []
 # 反向交割合约类型列表
 symbols_future: List[str] = []
 
+# USDT永续合约类型列表
+symbols_usdt: List[str] = []
+
 # 本地委托号缓存集合
 local_orderids: Set[str] = set()
 
@@ -112,6 +116,7 @@ class BybitGateway(BaseGateway):
         "服务器": ["REAL", "TESTNET"],
         "代理地址": "",
         "代理端口": "",
+        "合约模式": ["反向", "正向"]
     }
 
     exchanges: List[Exchange] = [Exchange.BYBIT]
@@ -120,12 +125,22 @@ class BybitGateway(BaseGateway):
         """构造函数"""
         super().__init__(event_engine, gateway_name)
 
-        self.rest_api: "BybitRestApi" = BybitRestApi(self)
-        self.private_ws_api: "BybitPrivateWebsocketApi" = BybitPrivateWebsocketApi(self)
-        self.public_ws_api: "BybitPublicWebsocketApi" = BybitPublicWebsocketApi(self)
+        self.not_connected: bool = True
 
     def connect(self, setting: dict) -> None:
         """连接交易接口"""
+        if setting["合约模式"] == "正向":
+            self.rest_api: "BybitUsdtRestApi" = BybitUsdtRestApi(self)
+            self.private_ws_api: "BybitUsdtPrivateWebsocketApi" = BybitUsdtPrivateWebsocketApi(self)
+            self.public_ws_api: "BybitUsdtPublicWebsocketApi" = BybitUsdtPublicWebsocketApi(self)
+
+        else:
+            self.rest_api: "BybitInverseRestApi" = BybitInverseRestApi(self)
+            self.private_ws_api: "BybitInversePrivateWebsocketApi" = BybitInversePrivateWebsocketApi(self)
+            self.public_ws_api: "BybitInversePublicWebsocketApi" = BybitInversePublicWebsocketApi(self)
+
+        self.not_connected = False
+
         key: str = setting["ID"]
         secret: str = setting["Secret"]
         server: str = setting["服务器"]
@@ -182,12 +197,13 @@ class BybitGateway(BaseGateway):
 
     def close(self) -> None:
         """关闭连接"""
-        self.rest_api.stop()
-        self.private_ws_api.stop()
-        self.public_ws_api.stop()
+        if not self.not_connected:
+            self.rest_api.stop()
+            self.private_ws_api.stop()
+            self.public_ws_api.stop()
 
 
-class BybitRestApi(RestClient):
+class BybitInverseRestApi(RestClient):
     """"""
 
     def __init__(self, gateway: BybitGateway) -> None:
@@ -681,7 +697,7 @@ class BybitRestApi(RestClient):
         return history
 
 
-class BybitPublicWebsocketApi(WebsocketClient):
+class BybitInversePublicWebsocketApi(WebsocketClient):
     """"""
 
     def __init__(self, gateway: BybitGateway) -> None:
@@ -820,8 +836,7 @@ class BybitPublicWebsocketApi(WebsocketClient):
 
             tick.last_price = update["last_price_e4"] / 10000
 
-            if "volume_24h" in update:
-                tick.volume = update["volume_24h"]
+            tick.volume = update["volume_24h"]
 
             update_time: str = update.get("updated_at", None)
             if update_time:
@@ -895,7 +910,7 @@ class BybitPublicWebsocketApi(WebsocketClient):
         self.gateway.on_tick(copy(tick))
 
 
-class BybitPrivateWebsocketApi(WebsocketClient):
+class BybitInversePrivateWebsocketApi(WebsocketClient):
     """"""
 
     def __init__(self, gateway: BybitGateway) -> None:
@@ -1088,6 +1103,876 @@ class BybitPrivateWebsocketApi(WebsocketClient):
                 gateway_name=self.gateway_name,
             )
             self.gateway.on_account(account)
+
+
+class BybitUsdtRestApi(RestClient):
+    """"""
+
+    def __init__(self, gateway: BybitGateway) -> None:
+        """构造函数"""
+        super().__init__()
+
+        self.gateway: BybitGateway = gateway
+        self.gateway_name: str = gateway.gateway_name
+
+        self.key: str = ""
+        self.secret: bytes = b""
+
+        self.order_count: int = 0
+
+    def sign(self, request: Request) -> Request:
+        """ 生成ByBit签名"""
+        request.headers = {"Referer": "vn.py"}
+
+        if request.method == "GET":
+            api_params: dict = request.params
+            if api_params is None:
+                api_params = request.params = {}
+        else:
+            api_params: dict = request.data
+            if api_params is None:
+                api_params = request.data = {}
+
+        api_params["api_key"] = self.key
+        api_params["recv_window"] = 30 * 1000
+        api_params["timestamp"] = generate_timestamp(-5)
+
+        data2sign = "&".join(
+            [f"{k}={v}" for k, v in sorted(api_params.items())])
+        signature: str = sign(self.secret, data2sign.encode())
+        api_params["sign"] = signature
+
+        return request
+
+    def new_orderid(self) -> str:
+        """生成本地委托号"""
+        prefix: str = datetime.now().strftime("%Y%m%d-%H%M%S-")
+
+        self.order_count += 1
+        suffix: str = str(self.order_count).rjust(8, "0")
+
+        orderid: str = prefix + suffix
+        return orderid
+
+    def connect(
+        self,
+        key: str,
+        secret: str,
+        server: str,
+        proxy_host: str,
+        proxy_port: int,
+    ) -> None:
+        """连接REST服务器"""
+        self.key = key
+        self.secret = secret.encode()
+
+        if server == "REAL":
+            self.init(REST_HOST, proxy_host, proxy_port)
+        else:
+            self.init(TESTNET_REST_HOST, proxy_host, proxy_port)
+
+        self.start(3)
+        self.gateway.write_log("REST API启动成功")
+
+        self.query_contract()
+
+    def send_order(self, req: OrderRequest) -> str:
+        """委托下单"""
+        # 检查委托类型是否正确
+        if req.type not in ORDER_TYPE_VT2BYBIT:
+            self.gateway.write_log(f"委托失败，不支持的委托类型：{req.type.value}")
+            return
+
+        # 检查合约代码是否正确并根据合约类型判断下单接口
+        if req.symbol in symbols_usdt:
+            path: str = "/private/linear/order/create"
+        else:
+            self.gateway.write_log(f"委托失败，找不到该合约代码{req.symbol}")
+            return
+
+        # 生成本地委托号
+        orderid: str = self.new_orderid()
+        # 推送提交中事件
+        order: OrderData = req.create_order_data(orderid, self.gateway_name)
+
+        # 生成委托请求
+        data: dict = {
+            "symbol": req.symbol,
+            "side": DIRECTION_VT2BYBIT[req.direction],
+            "qty": req.volume,
+            "order_link_id": orderid,
+            "time_in_force": "GoodTillCancel",
+            "reduce_only": False,
+            "close_on_trigger": False
+        }
+
+        data["order_type"] = ORDER_TYPE_VT2BYBIT[req.type]
+        data["price"] = req.price
+
+        if req.offset == Offset.CLOSE:
+            data["reduce_only"] = True
+
+        self.add_request(
+            "POST",
+            path,
+            callback=self.on_send_order,
+            data=data,
+            extra=order,
+            on_failed=self.on_send_order_failed,
+            on_error=self.on_send_order_error,
+        )
+
+        self.gateway.on_order(order)
+        return order.vt_orderid
+
+    def on_send_order_failed(
+        self,
+        status_code: int,
+        request: Request
+    ) -> None:
+        """委托下单失败服务器报错回报"""
+        order: OrderData = request.extra
+        order.status = Status.REJECTED
+        self.gateway.on_order(order)
+
+        data: dict = request.response.json()
+        error_msg: str = data["ret_msg"]
+        error_code: int = data["ret_code"]
+        msg = f"委托失败，错误代码:{error_code},  错误信息：{error_msg}"
+        self.gateway.write_log(msg)
+
+    def on_send_order_error(
+        self,
+        exception_type: type,
+        exception_value: Exception,
+        tb,
+        request: Request
+    ) -> None:
+        """委托下单回报函数报错回报"""
+        order: OrderData = request.extra
+        order.status = Status.REJECTED
+        self.gateway.on_order(order)
+
+        if not issubclass(exception_type, ConnectionError):
+            self.on_error(exception_type, exception_value, tb, request)
+
+    def on_send_order(self, data: dict, request: Request) -> None:
+        """委托下单回报"""
+        if self.check_error("委托下单", data):
+            order: OrderData = request.extra
+            order.status = Status.REJECTED
+            self.gateway.on_order(order)
+            return
+
+    def cancel_order(self, req: CancelRequest) -> None:
+        """委托撤单"""
+        # 检查合约代码是否正确并根据合约类型判断撤单接口
+        if req.symbol in symbols_usdt:
+            path: str = "/private/linear/order/cancel"
+        else:
+            self.gateway.write_log(f"撤单失败，找不到该合约代码{req.symbol}")
+            return
+
+        data: dict = {"symbol": req.symbol}
+
+        # 检查是否为本地委托号
+        if req.orderid in local_orderids:
+            data["order_link_id"] = req.orderid
+        else:
+            data["order_id"] = req.orderid
+
+        self.add_request(
+            "POST",
+            path,
+            data=data,
+            callback=self.on_cancel_order
+        )
+
+    def on_cancel_order_error(
+        self,
+        exception_type: type,
+        exception_value: Exception,
+        tb,
+        request: Request
+    ) -> None:
+        """委托撤单回报函数报错回报"""
+        if not issubclass(exception_type, ConnectionError):
+            self.on_error(exception_type, exception_value, tb, request)
+
+    def on_cancel_order(self, data: dict, request: Request) -> None:
+        """委托撤单回报"""
+        if self.check_error("委托撤单", data):
+            return
+
+    def on_failed(self, status_code: int, request: Request) -> None:
+        """处理请求失败回报"""
+        try:
+            data: dict = request.response.json()
+            error_msg: str = data["ret_msg"]
+            error_code: int = data["ret_code"]
+            msg = f"请求失败，状态码：{request.status}，错误代码：{error_code}, 信息：{error_msg}"
+        except JSONDecodeError:
+            text: str = request.response.text
+            msg = f"请求失败，信息：{text}"
+
+        self.gateway.write_log(msg)
+
+    def on_error(
+        self,
+        exception_type: type,
+        exception_value: Exception,
+        tb,
+        request: Request
+    ) -> None:
+        """触发异常回报"""
+        msg = f"触发异常，状态码：{exception_type}，信息：{exception_value}"
+        self.gateway.write_log(msg)
+
+        sys.stderr.write(
+            self.exception_detail(exception_type, exception_value, tb, request)
+        )
+
+    def on_query_position(self, data: dict, request: Request) -> None:
+        """持仓查询回报"""
+        if self.check_error("查询持仓", data):
+            return
+
+        data = data["result"]
+
+        for d in data:
+            d = d["data"]
+
+            if d["size"]:
+                position: PositionData = PositionData(
+                    symbol=d["symbol"],
+                    exchange=Exchange.BYBIT,
+                    direction=DIRECTION_BYBIT2VT[d["side"]],
+                    volume=d["size"],
+                    price=d["entry_price"],
+                    gateway_name=self.gateway_name
+                )
+                self.gateway.on_position(position)
+
+    def on_query_contract(self, data: dict, request: Request) -> None:
+        """合约查询回报"""
+        if self.check_error("查询合约", data):
+            return
+
+        for d in data["result"]:
+            # 提取信息生成合约对象
+            contract: ContractData = ContractData(
+                symbol=d["name"],
+                exchange=Exchange.BYBIT,
+                name=d["name"],
+                product=Product.FUTURES,
+                size=1,
+                pricetick=float(d["price_filter"]["tick_size"]),
+                min_volume=d["lot_size_filter"]["min_trading_qty"],
+                history_data=True,
+                gateway_name=self.gateway_name
+            )
+
+            # 缓存正向永续合约信息并推送
+            if d["quote_currency"] == "USDT":
+                symbols_usdt.append(d["name"])
+                self.gateway.on_contract(contract)
+
+        self.gateway.write_log("合约信息查询成功")
+        self.query_position()
+        self.query_account()
+        self.query_order()
+
+    def on_query_account(self, data: dict, request: Request) -> None:
+        """资金查询回报"""
+        if self.check_error("查询账号", data):
+            return
+
+        for key, value in data["result"].items():
+            if key == "USDT":
+                account: AccountData = AccountData(
+                    accountid=key,
+                    balance=value["wallet_balance"],
+                    frozen=value["used_margin"],
+                    gateway_name=self.gateway_name,
+                )
+                self.gateway.on_account(account)
+                self.gateway.write_log(f"{key}资金信息查询成功")
+
+    def on_query_order(self, data: dict, request: Request):
+        """未成交委托查询回报"""
+        if self.check_error("查询委托", data):
+            return
+
+        if not data["result"]:
+            return
+
+        # 检查是否为本地委托号
+        for d in data["result"]:
+            orderid: str = d["order_link_id"]
+            if orderid:
+                local_orderids.add(orderid)
+            else:
+                orderid: str = d["order_id"]
+
+            dt: datetime = generate_datetime(d["created_time"])
+
+            order: OrderData = OrderData(
+                symbol=d["symbol"],
+                exchange=Exchange.BYBIT,
+                orderid=orderid,
+                type=ORDER_TYPE_BYBIT2VT[d["order_type"]],
+                direction=DIRECTION_BYBIT2VT[d["side"]],
+                price=d["price"],
+                volume=d["qty"],
+                traded=d["cum_exec_qty"],
+                status=STATUS_BYBIT2VT[d["order_status"]],
+                datetime=dt,
+                gateway_name=self.gateway_name
+            )
+            offset: bool = d["reduce_only"]
+            if offset:
+                order.offset = Offset.CLOSE
+            else:
+                order.offset = Offset.OPEN
+
+            self.gateway.on_order(order)
+
+        self.gateway.write_log(f"{order.symbol}委托信息查询成功")
+
+    def query_contract(self) -> None:
+        """查询合约信息"""
+        self.add_request(
+            "GET",
+            "/v2/public/symbols",
+            self.on_query_contract
+        )
+
+    def check_error(self, name: str, data: dict) -> bool:
+        """回报状态检查"""
+        if data["ret_code"]:
+            error_code: int = data["ret_code"]
+            error_msg: str = data["ret_msg"]
+            msg = f"{name}失败，错误代码：{error_code}，信息：{error_msg}"
+            self.gateway.write_log(msg)
+            return True
+
+        return False
+
+    def query_account(self) -> None:
+        """查询资金"""
+        self.add_request(
+            "GET",
+            "/v2/private/wallet/balance",
+            self.on_query_account
+        )
+
+    def query_position(self) -> None:
+        """查询持仓"""
+        path_usdt: str = "/private/linear/position/list"
+        self.add_request(
+            "GET",
+            path_usdt,
+            self.on_query_position
+        )
+
+    def query_order(self) -> None:
+        """查询未成交委托"""
+
+        path_usdt: str = "/private/linear/order/search"
+        symbols: list = symbols_usdt
+
+        for symbol in symbols:
+            params: dict = {
+                "symbol": symbol
+            }
+
+            self.add_request(
+                "GET",
+                path_usdt,
+                callback=self.on_query_order,
+                params=params
+            )
+
+    def query_history(self, req: HistoryRequest) -> List[BarData]:
+        """查询历史数据"""
+        history: list = []
+        count: int = 200
+        start_time: int = int(req.start.timestamp())
+
+        path: str = "/public/linear/kline"
+
+        while True:
+            # 创建查询参数
+            params: dict = {
+                "symbol": req.symbol,
+                "interval": INTERVAL_VT2BYBIT[req.interval],
+                "from": start_time,
+                "limit": count
+            }
+
+            # 从服务器获取响应
+            resp: Response = self.request(
+                "GET",
+                path,
+                params=params
+            )
+
+            # 如果请求失败则终止循环
+            if resp.status_code // 100 != 2:
+                msg = f"获取历史数据失败，状态码：{resp.status_code}，信息：{resp.text}"
+                self.gateway.write_log(msg)
+                break
+            else:
+                data: dict = resp.json()
+
+                ret_code: int = data["ret_code"]
+                if ret_code:
+                    ret_msg: str = data["ret_msg"]
+                    msg = f"获取历史数据出错，错误信息：{ret_msg}"
+                    self.gateway.write_log(msg)
+                    break
+
+                if not data["result"]:
+                    msg = f"获取历史数据为空，开始时间：{start_time}，数量：{count}"
+                    self.gateway.write_log(msg)
+                    break
+
+                buf: list = []
+                for d in data["result"]:
+                    dt: datetime = generate_datetime_2(d["open_time"])
+
+                    bar: BarData = BarData(
+                        symbol=req.symbol,
+                        exchange=req.exchange,
+                        datetime=dt,
+                        interval=req.interval,
+                        volume=float(d["volume"]),
+                        open_price=float(d["open"]),
+                        high_price=float(d["high"]),
+                        low_price=float(d["low"]),
+                        close_price=float(d["close"]),
+                        gateway_name=self.gateway_name
+                    )
+                    buf.append(bar)
+
+                history.extend(buf)
+
+                begin: datetime = buf[0].datetime
+                end: datetime = buf[-1].datetime
+                msg = f"获取历史数据成功，{req.symbol} - {req.interval.value}，{begin} - {end}"
+                self.gateway.write_log(msg)
+
+                # 收到最后数据则结束循环
+                if len(buf) < count:
+                    break
+
+                # 更新开始时间
+                start_time: int = int((bar.datetime + TIMEDELTA_MAP[req.interval]).timestamp())
+
+        return history
+
+
+class BybitUsdtPublicWebsocketApi(WebsocketClient):
+    """"""
+
+    def __init__(self, gateway: BybitGateway) -> None:
+        """构造函数"""
+        super().__init__()
+
+        self.gateway: BybitGateway = gateway
+        self.gateway_name: str = gateway.gateway_name
+
+        self.callbacks: Dict[str, Callable] = {}
+        self.ticks: Dict[str, TickData] = {}
+        self.subscribed: Dict[str, SubscribeRequest] = {}
+
+        self.symbol_bids: Dict[str, dict] = {}
+        self.symbol_asks: Dict[str, dict] = {}
+
+    def connect(
+        self,
+        server: str,
+        proxy_host: str,
+        proxy_port: int
+    ) -> None:
+        """连接Websocket公共频道"""
+        self.proxy_host = proxy_host
+        self.proxy_port = proxy_port
+        self.server = server
+
+        if self.server == "REAL":
+            url = PUBLIC_WEBSOCKET_HOST
+        else:
+            url = TESTNET_PUBLIC_WEBSOCKET_HOST
+
+        self.init(url, self.proxy_host, self.proxy_port)
+        self.start()
+
+    def on_connected(self) -> None:
+        """连接成功回报"""
+        self.gateway.write_log("行情Websocket API连接成功")
+
+        if self.subscribed:
+            for req in self.subscribed.values():
+                self.subscribe(req)
+
+    def on_disconnected(self) -> None:
+        """连接断开回报"""
+        self.gateway.write_log("行情Websocket API连接断开")
+
+    def subscribe(self, req: SubscribeRequest) -> None:
+        """订阅行情"""
+
+        if req.symbol in self.subscribed:
+            return
+
+        # 缓存订阅记录
+        self.subscribed[req.symbol] = req
+
+        # 创建TICK对象
+        tick: TickData = TickData(
+            symbol=req.symbol,
+            exchange=req.exchange,
+            datetime=datetime.now(),
+            name=req.symbol,
+            gateway_name=self.gateway_name
+        )
+        self.ticks[req.symbol] = tick
+
+        # 发送订阅请求
+        self.subscribe_topic(f"instrument_info.100ms.{req.symbol}", self.on_tick)
+        self.subscribe_topic(f"orderBookL2_25.{req.symbol}", self.on_depth)
+
+    def subscribe_topic(
+        self,
+        topic: str,
+        callback: Callable[[str, dict], Any]
+    ) -> None:
+        """订阅公共频道推送"""
+        self.callbacks[topic] = callback
+
+        req: dict = {
+            "op": "subscribe",
+            "args": [topic],
+        }
+        self.send_packet(req)
+
+    def on_packet(self, packet: dict) -> None:
+        """推送数据回报"""
+        if "topic" not in packet:
+            op: str = packet["request"]["op"]
+            if op == "auth":
+                self.on_login(packet)
+        else:
+            channel: str = packet["topic"]
+            callback: callable = self.callbacks[channel]
+            callback(packet)
+
+    def on_error(
+        self,
+        exception_type: type,
+        exception_value: Exception,
+        tb
+    ) -> None:
+        """触发异常回报"""
+        msg = f"触发异常，状态码：{exception_type}，信息：{exception_value}"
+        self.gateway.write_log(msg)
+
+        sys.stderr.write(self.exception_detail(
+            exception_type, exception_value, tb))
+
+    def on_tick(self, packet: dict) -> None:
+        """行情推送回报"""
+        topic: str = packet["topic"]
+        type_: str = packet["type"]
+        data: dict = packet["data"]
+
+        symbol: str = topic.replace("instrument_info.100ms.", "")
+        tick: TickData = self.ticks[symbol]
+
+        if type_ == "snapshot":
+            if not data["last_price_e4"]:           # 过滤最新价为0的数据
+                return
+
+            tick.last_price = int(data["last_price_e4"]) / 10000
+
+            tick.volume = int(data["volume_24h_e8"]) / 100000000
+
+            tick.datetime = generate_datetime(data["updated_at"])
+
+        else:
+            update: dict = data["update"][0]
+
+            if "last_price_e4" not in update:      # 过滤最新价为0的数据
+                return
+
+            tick.last_price = int(update["last_price_e4"]) / 10000
+
+            tick.volume = int(update["volume_24h_e8"]) / 100000000
+
+            tick.datetime = generate_datetime(update["updated_at"])
+
+        self.gateway.on_tick(copy(tick))
+
+    def on_depth(self, packet: dict) -> None:
+        """盘口推送回报"""
+        topic: str = packet["topic"]
+        type_: str = packet["type"]
+        data: dict = packet["data"]
+        if not data:
+            return
+
+        symbol: str = topic.replace("orderBookL2_25.", "")
+        tick: TickData = self.ticks[symbol]
+        bids: dict = self.symbol_bids.setdefault(symbol, {})
+        asks: dict = self.symbol_asks.setdefault(symbol, {})
+
+        if type_ == "snapshot":
+
+            buf: list = data["order_book"]
+
+            for d in buf:
+                price: float = float(d["price"])
+
+                if d["side"] == "Buy":
+                    bids[price] = d
+                else:
+                    asks[price] = d
+        else:
+            for d in data["delete"]:
+                price: float = float(d["price"])
+
+                if d["side"] == "Buy":
+                    bids.pop(price)
+                else:
+                    asks.pop(price)
+
+            for d in (data["update"] + data["insert"]):
+
+                price: float = float(d["price"])
+                if d["side"] == "Buy":
+                    bids[price] = d
+                else:
+                    asks[price] = d
+
+        bid_keys: list = list(bids.keys())
+        bid_keys.sort(reverse=True)
+
+        ask_keys: list = list(asks.keys())
+        ask_keys.sort()
+
+        for i in range(5):
+            n = i + 1
+
+            bid_price = bid_keys[i]
+            bid_data = bids[bid_price]
+            ask_price = ask_keys[i]
+            ask_data = asks[ask_price]
+
+            setattr(tick, f"bid_price_{n}", bid_price)
+            setattr(tick, f"bid_volume_{n}", bid_data["size"])
+            setattr(tick, f"ask_price_{n}", ask_price)
+            setattr(tick, f"ask_volume_{n}", ask_data["size"])
+
+        tick.datetime = generate_datetime_2(int(packet["timestamp_e6"]) / 1000000)
+        self.gateway.on_tick(copy(tick))
+
+
+class BybitUsdtPrivateWebsocketApi(WebsocketClient):
+    """"""
+
+    def __init__(self, gateway: BybitGateway) -> None:
+        """构造函数"""
+        super().__init__()
+
+        self.gateway: BybitGateway = gateway
+        self.gateway_name: str = gateway.gateway_name
+
+        self.key: str = ""
+        self.secret: bytes = b""
+        self.server: str = ""
+
+        self.callbacks: Dict[str, Callable] = {}
+        self.ticks: Dict[str, TickData] = {}
+        self.subscribed: Dict[str, SubscribeRequest] = {}
+
+        self.symbol_bids: Dict[str, dict] = {}
+        self.symbol_asks: Dict[str, dict] = {}
+
+    def connect(
+        self,
+        key: str,
+        secret: str,
+        server: str,
+        proxy_host: str,
+        proxy_port: int
+    ) -> None:
+        """连接Websocket私有频道"""
+        self.key = key
+        self.secret = secret.encode()
+        self.proxy_host = proxy_host
+        self.proxy_port = proxy_port
+        self.server = server
+
+        if self.server == "REAL":
+            url = PRIVATE_WEBSOCKET_HOST
+        else:
+            url = TESTNET_PRIVATE_WEBSOCKET_HOST
+
+        self.init(url, self.proxy_host, self.proxy_port)
+        self.start()
+
+    def login(self) -> None:
+        """用户登录"""
+        expires: int = generate_timestamp(30)
+        msg = f"GET/realtime{int(expires)}"
+        signature: str = sign(self.secret, msg.encode())
+
+        req: dict = {
+            "op": "auth",
+            "args": [self.key, expires, signature]
+        }
+        self.send_packet(req)
+
+    def subscribe_topic(
+        self,
+        topic: str,
+        callback: Callable[[str, dict], Any]
+    ) -> None:
+        """订阅私有频道"""
+        self.callbacks[topic] = callback
+
+        req: dict = {
+            "op": "subscribe",
+            "args": [topic],
+        }
+        self.send_packet(req)
+
+    def on_connected(self) -> None:
+        """连接成功回报"""
+        self.gateway.write_log("交易Websocket API连接成功")
+        self.login()
+
+    def on_disconnected(self) -> None:
+        """连接断开回报"""
+        self.gateway.write_log("交易Websocket API连接断开")
+
+    def on_packet(self, packet: dict) -> None:
+        """推送数据回报"""
+        if "topic" not in packet:
+            op: str = packet["request"]["op"]
+            if op == "auth":
+                self.on_login(packet)
+        else:
+            channel: str = packet["topic"]
+            callback: callable = self.callbacks[channel]
+            callback(packet)
+
+    def on_error(
+        self,
+        exception_type: type,
+        exception_value: Exception,
+        tb
+    ) -> None:
+        """触发异常回报"""
+        msg = f"触发异常，状态码：{exception_type}，信息：{exception_value}"
+        self.gateway.write_log(msg)
+
+        sys.stderr.write(self.exception_detail(
+            exception_type, exception_value, tb))
+
+    def on_login(self, packet: dict):
+        """用户登录请求回报"""
+        success: bool = packet.get("success", False)
+        if success:
+            self.gateway.write_log("交易Websocket API登录成功")
+
+            self.subscribe_topic("order", self.on_order)
+            self.subscribe_topic("execution", self.on_trade)
+            self.subscribe_topic("position", self.on_position)
+            self.subscribe_topic("wallet", self.on_account)
+
+        else:
+            self.gateway.write_log("交易Websocket API登录失败")
+
+    def on_account(self, packet: dict) -> None:
+        """"""
+        for d in packet["data"]:
+            account = AccountData(
+                accountid="USDT",
+                balance=d["wallet_balance"],
+                frozen=d["wallet_balance"] - d["available_balance"],
+                gateway_name=self.gateway_name,
+            )
+            self.gateway.on_account(account)
+
+    def on_trade(self, packet: dict) -> None:
+        """成交更新推送"""
+        # 检查是否为本地委托号
+        for d in packet["data"]:
+            orderid: str = d["order_link_id"]
+            if not orderid:
+                orderid: str = d["order_id"]
+
+            trade: TradeData = TradeData(
+                symbol=d["symbol"],
+                exchange=Exchange.BYBIT,
+                orderid=orderid,
+                tradeid=d["exec_id"],
+                direction=DIRECTION_BYBIT2VT[d["side"]],
+                price=float(d["price"]),
+                volume=d["exec_qty"],
+                datetime=generate_datetime(d["trade_time"]),
+                gateway_name=self.gateway_name,
+            )
+
+            self.gateway.on_trade(trade)
+
+    def on_order(self, packet: dict) -> None:
+        """委托更新推送"""
+        # 检查是否为本地委托号
+        for d in packet["data"]:
+            orderid: str = d["order_link_id"]
+            if orderid:
+                local_orderids.add(orderid)
+            else:
+                orderid: str = d["order_id"]
+
+            dt: datetime = generate_datetime(d["create_time"])
+
+            order: OrderData = OrderData(
+                symbol=d["symbol"],
+                exchange=Exchange.BYBIT,
+                orderid=orderid,
+                type=ORDER_TYPE_BYBIT2VT[d["order_type"]],
+                direction=DIRECTION_BYBIT2VT[d["side"]],
+                price=float(d["price"]),
+                volume=d["qty"],
+                traded=d["cum_exec_qty"],
+                status=STATUS_BYBIT2VT[d["order_status"]],
+                datetime=dt,
+                gateway_name=self.gateway_name
+            )
+            offset: bool = d["reduce_only"]
+            if offset:
+                order.offset = Offset.CLOSE
+            else:
+                order.offset = Offset.OPEN
+
+            self.gateway.on_order(order)
+
+    def on_position(self, packet: dict) -> None:
+        """持仓更新推送"""
+        for d in packet["data"]:
+            position: PositionData = PositionData(
+                symbol=d["symbol"],
+                exchange=Exchange.BYBIT,
+                direction=DIRECTION_BYBIT2VT[d["side"]],
+                volume=d["size"],
+                price=float(d["entry_price"]),
+                gateway_name=self.gateway_name
+            )
+            self.gateway.on_position(position)
 
 
 def generate_timestamp(expire_after: float = 30) -> int:

--- a/vnpy_bybit/bybit_gateway.py
+++ b/vnpy_bybit/bybit_gateway.py
@@ -816,7 +816,7 @@ class BybitPublicWebsocketApi(WebsocketClient):
             update: dict = data["update"][0]
 
             if "last_price_e4" not in update:      # 过滤最新价为0的数据
-                    return
+                return
 
             tick.last_price = update["last_price_e4"] / 10000
 

--- a/vnpy_bybit/bybit_gateway.py
+++ b/vnpy_bybit/bybit_gateway.py
@@ -504,7 +504,7 @@ class BybitRestApi(RestClient):
         if not data["result"]:
             return
 
-       # 检查是否为本地委托号
+        # 检查是否为本地委托号
         for d in data["result"]:
             orderid: str = d["order_link_id"]
             if orderid:
@@ -1075,7 +1075,7 @@ class BybitPrivateWebsocketApi(WebsocketClient):
             balance: float = get_float_value(d, "wallet_balance")
             frozen: float = balance - get_float_value(d, "available_balance")
             account: AccountData = AccountData(
-                accountid=d["symbol"].replace("USD", ""),
+                accountid=d["symbol"].split("USD")[0],
                 balance=balance,
                 frozen=frozen,
                 gateway_name=self.gateway_name,

--- a/vnpy_bybit/bybit_gateway.py
+++ b/vnpy_bybit/bybit_gateway.py
@@ -736,6 +736,10 @@ class BybitPublicWebsocketApi(WebsocketClient):
 
     def subscribe(self, req: SubscribeRequest) -> None:
         """订阅行情"""
+
+        if req.symbol in self.subscribed:
+            return
+
         # 缓存订阅记录
         self.subscribed[req.symbol] = req
 


### PR DESCRIPTION
COMMIT 1：
因为反向合约接口没有websocket的wallet推送，需要通过仓位更新推送的数据更新资金。之前版本的accoutid是去掉了symbol字段的”USD“，但反向交割合约的symbol推送去掉USD后还有”M21“等字段。故改成只取symbol字段中”USD“字符之前的部分来获取accountid

COMMIT 2：
增加了已订阅的品种不再订阅的判断

COMMIT 3:
3.1:删除了没有用到的OPPOSITE_DIRECTION；
3.2.因为行情频道增量推送不再包含last_price_e4为必推字段，进行了相应修改；

3.3.修改最新价推送的时间戳获取：

包含last_price_e4字段推送的行情信息如下图所示：
![7ebef655d143f1581a4e5f10cfe991a](https://user-images.githubusercontent.com/63988546/122176278-026d8100-ceb7-11eb-830a-3bd420d3ca89.png)

反向永续合约：第一次推送和增量推送更新均有updated_at字段推送；

反向交割合约：第一次推送有updated_at_e9字段推送，增量推送没有对应时间戳字段推送，只能像on_depth中一样，获取timestamp_e6字段做时间戳转换

COMMIT 4：
修改缩进

COMMIT 5：
添加正向合约（双向持仓）支持